### PR TITLE
#4 Changes to other players' vaults overwrites the current player's vault

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cc.chaoticweg.mc</groupId>
     <artifactId>PersonalVault</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-beta</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/cc/chaoticweg/mc/personalvault/MetadataManager.java
+++ b/src/main/java/cc/chaoticweg/mc/personalvault/MetadataManager.java
@@ -1,10 +1,12 @@
 package cc.chaoticweg.mc.personalvault;
 
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 /**
@@ -13,6 +15,7 @@ import java.util.logging.Logger;
 class MetadataManager {
 
     private static final String VIEWING_KEY = "pv.viewing";
+    private static final String VIEWING_TARGET = "pv.viewing.target";
 
     private final PersonalVaultPlugin plugin;
     private final Logger logger;
@@ -26,11 +29,24 @@ class MetadataManager {
      * Set a metadata flag that represents whether a player is viewing their vault currently.
      *
      * @param player The player whose metadata we are setting
-     * @param viewing Whether the player is viewing their vault
+     * @param target Whose inventory the player is now viewing
      */
-    void setViewing(@NotNull Player player, boolean viewing) {
-        this.logger.fine("Setting " + player.getName() + " viewing metadata to " + viewing);
-        player.setMetadata(VIEWING_KEY, new FixedMetadataValue(this.plugin, viewing));
+    void setViewing(@NotNull Player player, @NotNull OfflinePlayer target) {
+        String targetUuidStr = target.getUniqueId().toString();
+        this.logger.fine("Setting " + player.getName() + " viewing metadata to " + targetUuidStr);
+        player.setMetadata(VIEWING_KEY, new FixedMetadataValue(this.plugin, true));
+        player.setMetadata(VIEWING_TARGET, new FixedMetadataValue(this.plugin, targetUuidStr));
+    }
+
+    /**
+     * Clear metadata flags for player, i.e. has closed the inventory they were viewing
+     *
+     * @param player The player who has stopped viewing an inventory
+     */
+    void setNotViewing(@NotNull Player player) {
+        this.logger.fine("Setting " + player.getName() + " viewing metadata to NULL");
+        player.setMetadata(VIEWING_KEY, new FixedMetadataValue(this.plugin, false));
+        player.removeMetadata(VIEWING_TARGET, this.plugin);
     }
 
     /**
@@ -41,6 +57,21 @@ class MetadataManager {
      */
     boolean isViewing(@NotNull Player player) {
         return player.hasMetadata(VIEWING_KEY) && player.getMetadata(VIEWING_KEY).get(0).asBoolean();
+    }
+
+    /**
+     * Get the UUID of the player whose inventory the player is viewing
+     *
+     * @param player Inventory viewer
+     * @return UUID of target, or null if none
+     */
+    UUID getViewingTarget(@NotNull Player player) {
+        if (!this.isViewing(player) || !player.hasMetadata(VIEWING_TARGET)) {
+            return null;
+        }
+
+        String targetUuidStr = player.getMetadata(VIEWING_TARGET).get(0).asString();
+        return UUID.fromString(targetUuidStr);
     }
 
 }

--- a/src/main/java/cc/chaoticweg/mc/personalvault/PersonalVaultPlugin.java
+++ b/src/main/java/cc/chaoticweg/mc/personalvault/PersonalVaultPlugin.java
@@ -26,7 +26,7 @@ public class PersonalVaultPlugin extends JavaPlugin {
         this.pvio = new PVIO(this.getDataFolder(), this.getLogger());
 
         this.metadata = new MetadataManager(this);
-        this.vaults = new VaultManager(this.pvio, this.metadata);
+        this.vaults = new VaultManager(this, this.pvio, this.metadata);
     }
 
     @Override

--- a/src/main/java/cc/chaoticweg/mc/personalvault/VaultManager.java
+++ b/src/main/java/cc/chaoticweg/mc/personalvault/VaultManager.java
@@ -20,10 +20,12 @@ public class VaultManager {
     private final ConcurrentHashMap<UUID, Inventory> vaults = new ConcurrentHashMap<>();
     private final Logger logger = Bukkit.getLogger();
 
+    private final PersonalVaultPlugin plugin;
     private final MetadataManager metadata;
     private final PVIO pvio;
 
-    VaultManager(@NotNull PVIO io, @NotNull MetadataManager metadata) {
+    VaultManager(@NotNull PersonalVaultPlugin plugin, @NotNull PVIO io, @NotNull MetadataManager metadata) {
+        this.plugin = Objects.requireNonNull(plugin);
         this.pvio = Objects.requireNonNull(io);
         this.metadata = Objects.requireNonNull(metadata);
     }
@@ -79,7 +81,7 @@ public class VaultManager {
     public void open(@NotNull Player player, @NotNull OfflinePlayer target) {
         Inventory vault = this.get(Objects.requireNonNull(target));
         player.openInventory(vault);
-        this.metadata.setViewing(player, true);
+        this.metadata.setViewing(player, target);
     }
 
     /**
@@ -98,8 +100,10 @@ public class VaultManager {
      * @param inv The inventory to save
      */
     public void close(@NotNull Player player, @NotNull Inventory inv) {
-        this.save(player, inv);
-        this.metadata.setViewing(player, false);
+        UUID targetUuid = this.metadata.getViewingTarget(player);
+        OfflinePlayer target = this.plugin.getServer().getOfflinePlayer(targetUuid);
+        this.save(target, inv);
+        this.metadata.setNotViewing(player);
     }
 
     /**

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ main: cc.chaoticweg.mc.personalvault.PersonalVaultPlugin
 prefix: PV
 
 name: PersonalVault
-version: 1.0.0
+version: 1.1.1-beta
 author: ChaoticWeg
 
 description: Provides a personal vault that can be accessed from anywhere.


### PR DESCRIPTION
Add UUID of target player to player metadata on viewing start, remove on viewing stop. Always save the target's inv rather than the player's.